### PR TITLE
Cleanup benchmark gradle files, use shared benchmark version definition

### DIFF
--- a/BenchmarkNdkSample/benchmark/build.gradle
+++ b/BenchmarkNdkSample/benchmark/build.gradle
@@ -32,7 +32,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    androidTestImplementation "androidx.benchmark:benchmark-junit4:1.0.0-beta01"
+    androidTestImplementation "androidx.benchmark:benchmark-junit4:$benchmark_version"
     androidTestImplementation "androidx.annotation:annotation-experimental:1.0.0-beta01"
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/BenchmarkNdkSample/build.gradle
+++ b/BenchmarkNdkSample/build.gradle
@@ -1,16 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.50'
+    ext.benchmark_version = '1.0.0-beta01'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.0"
+        classpath "com.android.tools.build:gradle:3.5.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.benchmark:benchmark-gradle-plugin:1.0.0-beta01"
+        classpath "androidx.benchmark:benchmark-gradle-plugin:$benchmark_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/BenchmarkSample/benchmark/build.gradle
+++ b/BenchmarkSample/benchmark/build.gradle
@@ -3,20 +3,15 @@ apply plugin: 'kotlin-android'
 apply plugin: 'androidx.benchmark'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
-
-        testInstrumentationRunner "androidx.benchmark.junit4.AndroidBenchmarkRunner"
+        targetSdkVersion 29
     }
 
     buildTypes {
         debug {
-            debuggable false
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'benchmark-proguard-rules.pro'
         }
@@ -32,7 +27,7 @@ dependencies {
 
     androidTestImplementation project(":ui")
     androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    androidTestImplementation "androidx.benchmark:benchmark-junit4:1.0.0-beta01"
+    androidTestImplementation "androidx.benchmark:benchmark-junit4:$benchmark_version"
 
     androidTestImplementation 'junit:junit:4.12'
 

--- a/BenchmarkSample/build.gradle
+++ b/BenchmarkSample/build.gradle
@@ -1,16 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.50'
+    ext.benchmark_version = '1.0.0-beta01'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.0"
+        classpath "com.android.tools.build:gradle:3.5.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.benchmark:benchmark-gradle-plugin:1.0.0-beta01"
+        classpath "androidx.benchmark:benchmark-gradle-plugin:$benchmark_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/BenchmarkSample/ui/build.gradle
+++ b/BenchmarkSample/ui/build.gradle
@@ -2,24 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
-
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
+        targetSdkVersion 29
     }
 }
 


### PR DESCRIPTION
Update to 29, removed unneeded settings for libraries

Don't need to specify default instrumentation runner anymore.