### PR TITLE
Opt out of scoped storage (workaround android 10 compatibility)

### DIFF
--- a/BenchmarkSample/benchmark/src/androidTest/AndroidManifest.xml
+++ b/BenchmarkSample/benchmark/src/androidTest/AndroidManifest.xml
@@ -21,5 +21,6 @@
     <!-- Important: disable debuggable for accurate performance results -->
     <application
         android:debuggable="false"
+        android:requestLegacyExternalStorage="true"
         tools:replace="android:debuggable"/>
 </manifest>


### PR DESCRIPTION
Fixes the issue below (Android 10 only)

Task :benchmark:connectedDebugAndroidTest

com.example.benchmark.AutoBoxingBenchmark > integerAlloc[Pixel 3 - 10] FAILED
java.io.IOException: Failed to create file for benchmark report. Make sure the
instrumentation argument additionalOutputDir is set to a writable