### PR TITLE
More fully featured RecyclerView sample

### DIFF
--- a/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/TextBenchmarkUtils.kt
+++ b/BenchmarkSample/benchmark/src/androidTest/java/com/example/benchmark/TextBenchmarkUtils.kt
@@ -1,0 +1,54 @@
+package com.example.benchmark
+
+import kotlin.random.Random
+
+// a small number of strings reused frequently, expected to hit
+// in the word-granularity text layout cache
+private val CACHE_HIT_STRINGS =
+    arrayOf("a", "small", "number", "of", "strings", "reused", "frequently")
+
+/**
+ * This Random is reused by all benchmarks for selecting characters, so that each will select
+ * different characters for each word, though the count and length of each word will be consistent.
+ *
+ * You can move this definition into the buildRandomParagraph function to see the affect of the
+ * platform's text layout cache, when hitrate is artificially high due to string reuse.
+ */
+private val unstableRandom = Random(0)
+
+private val chars: List<Char> = List(26) { 'a' + it } + List(26) { 'A' + it }
+
+/**
+ * Builds a random paragraph string of words of ascii letters.
+ *
+ * @param hitPercentage defines the percentage of frequently used words. These words are expected to
+ * have their layout information cached by the platform, and to be fast - 30% is a very rough
+ * estimate of the hit rate in practice in English with arbitrary sample text.
+ *
+ * @param wordsInParagraph length of the paragraph to generate..
+ */
+fun buildRandomParagraph(
+    hitPercentage: Int = 30,
+    wordsInParagraph: Int = 50
+): String {
+    require(!(hitPercentage < 0 || hitPercentage > 100))
+    val stableRandom = Random(0)
+
+    val result = StringBuilder()
+    for (word in 0 until wordsInParagraph) {
+        if (word != 0) {
+            result.append(" ")
+        }
+        if (stableRandom.nextInt(100) < hitPercentage) {
+            // add a common word, which is very likely to hit in the cache
+            result.append(CACHE_HIT_STRINGS[stableRandom.nextInt(CACHE_HIT_STRINGS.size)])
+        } else {
+            // construct a random word, which will *most likely* miss in the layout cache
+            for (j in 0 until stableRandom.nextInt(4, 9)) {
+                // add random letter
+                result.append(chars[unstableRandom.nextInt(chars.size)])
+            }
+        }
+    }
+    return result.toString()
+}

--- a/BenchmarkSample/ui/src/main/res/layout/activity_main.xml
+++ b/BenchmarkSample/ui/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<androidx.constraintlayout.widget.ConstraintLayout
+<FrameLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
@@ -25,4 +25,4 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>


### PR DESCRIPTION
Account for non-trivial text in the RecyclerView sample.

Also sets RV height=1 to ensure only one visible item at a time. This
ensures that each scroll triggers both adding an item, and removing
the old one.

Remove hardcoded item count, and generate items lazily.

On Pixel3XL, seeing very stable numbers:
```
benchmark:        34,066 ns RecyclerViewBenchmark.buildParagraph
benchmark:     3,271,771 ns RecyclerViewBenchmark.scroll
benchmark:     3,217,240 ns RecyclerViewBenchmark.scroll1
benchmark:     3,236,979 ns RecyclerViewBenchmark.scroll2
benchmark:     3,204,896 ns RecyclerViewBenchmark.scroll3
benchmark:     3,238,802 ns RecyclerViewBenchmark.scroll4
benchmark:     3,265,000 ns RecyclerViewBenchmark.scroll5
benchmark:     3,251,928 ns RecyclerViewBenchmark.scroll6
benchmark:     3,235,937 ns RecyclerViewBenchmark.scroll7
benchmark:     3,249,011 ns RecyclerViewBenchmark.scroll8
```
