### PR TITLE
Enable new benchmark reporting for non-canary users

### DIFF
--- a/BenchmarkNdkSample/gradle.properties
+++ b/BenchmarkNdkSample/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.enableAdditionalTestOutput=true

--- a/BenchmarkSample/gradle.properties
+++ b/BenchmarkSample/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.enableAdditionalTestOutput=true


### PR DESCRIPTION
This should make it easier to run the sample out of the box for users on 29+ devices, but haven't yet upgraded to a version of studio that enables test output via AGP by default