### PR TITLE
Fix ConstraintLayoutPerformance's run script.

### DIFF
--- a/ConstraintLayoutPerformance/run.sh
+++ b/ConstraintLayoutPerformance/run.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 current_dir=`basename $(pwd)`
-if [ $current_dir != "android-constraint-layout-performance" ];then
-    echo 'You need to run the script at the "android-constraint-layout-performance" directory'
+if [ $current_dir != "ConstraintLayoutPerformance" ];then
+    echo 'You need to run the script at the "ConstraintLayoutPerformance" directory'
     exit 1
 fi
 


### PR DESCRIPTION
The ConstraintLayoutPerformance directory was called android-constraint-layout-performance previously. The run script had some code to ensure the script was being executed from the mentioned directory, but the name hadn't been updated to the new one, so it was always failing.