### PR TITLE
Run FTL tests on `push` only.

### DIFF
--- a/.github/workflows/firebase_test_lab.yml
+++ b/.github/workflows/firebase_test_lab.yml
@@ -1,8 +1,6 @@
 name: Runs Macro Benchmarks on Firebase Test Lab
 
 on:
-  pull_request_target:
-    types: ['labeled']
   push:
     branches: [ macrobenchmark ]
   workflow_dispatch:


### PR DESCRIPTION
* Previously for debugging we had turned it on for the `pull_request_target` event.