### PR TITLE
Add an example for a benchmark with an `Activity` that is not exported.

### DIFF
--- a/MacrobenchmarkSample/app/src/main/AndroidManifest.xml
+++ b/MacrobenchmarkSample/app/src/main/AndroidManifest.xml
@@ -50,6 +50,18 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ActivityLauncherActivity"
+            android:exported="true">
+            <intent-filter>
+                <action
+                    android:name="com.example.macrobenchmark.target.ACTIVITY_LAUNCHER_ACTIVITY" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <!-- non-exported activities -->
+        <activity android:name=".NonExportedRecyclerActivity" />
+
         <!-- enable profiling by macrobenchmark -->
         <!--suppress AndroidElementNotAllowed -->
         <profileable android:shell="true" />

--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ActivityLauncherActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ActivityLauncherActivity.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.macrobenchmark.target
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Can launch other non-exported `Activities`.
+ */
+class ActivityLauncherActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_launcher)
+
+        val launchRecycler = findViewById<Button>(R.id.launchRecyclerActivity)
+        launchRecycler.setOnClickListener {
+            val intent = Intent(it.context, NonExportedRecyclerActivity::class.java)
+            // Create a new activity instance every single time
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
+        }
+    }
+}

--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/NonExportedRecyclerActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/NonExportedRecyclerActivity.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.macrobenchmark.target
+
+/**
+ * The same as a [RecyclerViewActivity], but not `exported` via the `AndroidManifest.xml`.
+ */
+class NonExportedRecyclerActivity : RecyclerViewActivity()

--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/RecyclerViewActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/RecyclerViewActivity.kt
@@ -21,7 +21,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
-class RecyclerViewActivity : AppCompatActivity() {
+open class RecyclerViewActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         title = "RecyclerView Sample"

--- a/MacrobenchmarkSample/app/src/main/res/layout/activity_launcher.xml
+++ b/MacrobenchmarkSample/app/src/main/res/layout/activity_launcher.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2021 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/launchRecyclerActivity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:contentDescription="@string/launchRecyclerActivity"
+        android:text="@string/launchRecyclerActivity"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MacrobenchmarkSample/app/src/main/res/values/strings.xml
+++ b/MacrobenchmarkSample/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
 <resources>
     <string name="app_notice">Macrobenchmark Target App.</string>
     <string name="recyclerDescription">A list of items</string>
+    <string name="launchRecyclerActivity">Launch Activity with a RecyclerView</string>
 </resources>

--- a/MacrobenchmarkSample/macrobenchmark/src/androidTest/java/com/example/macrobenchmark/NonExportedActivityBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/androidTest/java/com/example/macrobenchmark/NonExportedActivityBenchmark.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.macrobenchmark
+
+import android.content.Intent
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.filters.SdkSuppress
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+@LargeTest
+@SdkSuppress(minSdkVersion = 29)
+@RunWith(AndroidJUnit4::class)
+class NonExportedActivityBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun scroll() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val device = UiDevice.getInstance(instrumentation)
+        benchmarkRule.measureRepeated(
+            packageName = PACKAGE_NAME,
+            metrics = listOf(FrameTimingMetric()),
+            // Try switching to different compilation modes to see the effect
+            // it has on frame timing metrics.
+            compilationMode = CompilationMode.None,
+            iterations = 3,
+            setupBlock = {
+                // Before starting to measure, navigate to the UI to be measured
+                val intent = Intent()
+                intent.action = ACTION
+                // Ensures that a new activity is created every single time
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivityAndWait(intent)
+                // click a button to launch the target activity.
+                // While we use resourceId here to find the button, you could also use
+                // accessibility info or button text content.
+                val launchRecyclerActivity = device.findObject(
+                    By.res(PACKAGE_NAME, LAUNCH_RESOURCE_ID)
+                )
+                launchRecyclerActivity.click()
+                device.waitUntilActivity(RECYCLER_ACTIVITY_CLASS)
+            }
+        ) {
+            val recycler = device.findObject(
+                By.res(
+                    PACKAGE_NAME,
+                    RECYCLER_RESOURCE_ID
+                )
+            )
+            // Set gesture margin to avoid triggering gesture navigation
+            // with input events from automation.
+            recycler.setGestureMargin(device.displayWidth / 5)
+            for (i in 1..10) {
+                recycler.scroll(Direction.DOWN, 2f)
+                device.waitForIdle()
+            }
+        }
+    }
+
+    companion object {
+        private const val PACKAGE_NAME = "com.example.macrobenchmark.target"
+        private const val RECYCLER_ACTIVITY_CLASS = "$PACKAGE_NAME.NonExportedRecyclerActivity"
+        private const val ACTION = "$PACKAGE_NAME.ACTIVITY_LAUNCHER_ACTIVITY"
+        private const val LAUNCH_RESOURCE_ID = "launchRecyclerActivity"
+        private const val RECYCLER_RESOURCE_ID = "recycler"
+
+        /**
+         * Waits until an [android.app.Activity] with the given `className` is visible.
+         */
+        fun UiDevice.waitUntilActivity(className: String) {
+            wait(
+                Until.hasObject(
+                    By.clazz(className)
+                ),
+                TimeUnit.SECONDS.toMillis(10)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Test:

```
$ adb shell am instrument -w -m    -e debug false -e class 'com.example.macrobenchmark.NonExportedActivityBenchmark#start' com.example.macrobenchmark.test/androidx.test.runner.AndroidJUnitRunner
Connected to process 26738 on device 'google-pixel_5-06131FDD4000FF'.
benchmark: NonExportedActivityBenchmark_start
benchmark:   frameTime50thPercentileMs   min   5,   median   5,   max   5
benchmark:   frameTime90thPercentileMs   min   5,   median   5,   max   5
benchmark:   frameTime95thPercentileMs   min   5,   median   6,   max   7
benchmark:   frameTime99thPercentileMs   min   7,   median   9,   max  10
benchmark:             totalFrameCount   min 584,   median 588,   max 591
benchmark:
```