### PR TITLE
Fix package Name on Readme. 

### DIFF
--- a/MacrobenchmarkSample/functions/README.md
+++ b/MacrobenchmarkSample/functions/README.md
@@ -18,6 +18,6 @@ Example:
 
 ```bash
 # Example: Setup Environment Variables.
-package_name="com.example.macrobenchmark.test"
+package_name="com.example.macrobenchmark.target"
 device_configurations='["flame-30-en-portrait"]'
 ```


### PR DESCRIPTION
changed the package name 
from com.example.macrobenchmark.test  to  com.example.macrobenchmark.target
Issue #83 
https://github.com/android/performance-samples/blame/main/MacrobenchmarkSample/functions/README.md#L21