### PR TITLE
[Macrobenchmark] Add a basic Compose LazyList sample

### DIFF
--- a/MacrobenchmarkSample/app/build.gradle
+++ b/MacrobenchmarkSample/app/build.gradle
@@ -23,7 +23,7 @@ android {
     compileSdkVersion 31
     defaultConfig {
         applicationId "com.example.macrobenchmark.target"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"
@@ -32,6 +32,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        compose true
     }
 
     // [START macrobenchmark_setup_app_build_type]
@@ -56,6 +57,9 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    composeOptions {
+        kotlinCompilerExtensionVersion = compose_version
+    }
 }
 
 dependencies {
@@ -65,6 +69,11 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling:$compose_version"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/MacrobenchmarkSample/app/src/main/AndroidManifest.xml
+++ b/MacrobenchmarkSample/app/src/main/AndroidManifest.xml
@@ -49,6 +49,15 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".ComposeActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.macrobenchmark.target.COMPOSE_ACTIVITY" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <!-- non-exported activities -->
         <activity android:name=".NonExportedRecyclerActivity" />
 

--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
@@ -1,0 +1,91 @@
+package com.example.macrobenchmark.target
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Card
+import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+class ComposeActivity: ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // This argument allows the Macrobenchmark tests control the content being tested.
+        // In your app, you could use this approach to navigate to a consistent UI.
+        // e.g. Here the UI is being populated with a well known number of list items.
+        val itemCount = intent.getIntExtra(EXTRA_ITEM_COUNT, 1000)
+        val data = entries(itemCount)
+
+        setContent {
+            MaterialTheme {
+                LazyColumn(
+                    Modifier
+                        .fillMaxSize()
+                        .semantics {
+                            // There are no view ids in Compose so we use the content description
+                            // in order to find the Composable.
+                            contentDescription = LAZY_COLUMN_TAG
+                        }
+                ) {
+                    items(data, key = { it.contents }) { item ->
+                        EntryRow(entry = item, Modifier.padding(8.dp))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun entries(size: Int) = List(size) {
+        Entry("Item $it")
+    }
+
+    companion object {
+        const val EXTRA_ITEM_COUNT = "ITEM_COUNT"
+        const val LAZY_COLUMN_TAG = "MyLazyColumn"
+    }
+}
+
+@Composable
+private fun EntryRow(entry: Entry, modifier: Modifier = Modifier) {
+    Card(modifier = modifier) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = entry.contents,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .wrapContentSize()
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Checkbox(
+                checked = false,
+                onCheckedChange = {},
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun EntryRowPreview() {
+    val entry = Entry("Sample text")
+    EntryRow(entry = entry, Modifier.padding(8.dp))
+}

--- a/MacrobenchmarkSample/build.gradle
+++ b/MacrobenchmarkSample/build.gradle
@@ -17,7 +17,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = "1.6.10"
-    ext.benchmark_version = "1.1.0-beta01"
+    ext.benchmark_version = "1.1.0-beta02"
+    ext.compose_version = "1.1.0-rc03"
 
     repositories {
         google()

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
@@ -66,4 +66,31 @@ class FrameTimingBenchmark {
     }
     // [END macrobenchmark_control_your_app]
 
+    @Test
+    fun scrollComposeList() {
+        benchmarkRule.measureRepeated(
+            // [START_EXCLUDE]
+            packageName = TARGET_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            // Try switching to different compilation modes to see the effect
+            // it has on frame timing metrics.
+            compilationMode = CompilationMode.None(),
+            startupMode = StartupMode.WARM, // restarts activity each iteration
+            iterations = 10,
+            // [END_EXCLUDE]
+            setupBlock = {
+                // Before starting to measure, navigate to the UI to be measured
+                val intent = Intent("$packageName.COMPOSE_ACTIVITY")
+                startActivityAndWait(intent)
+            }
+        ) {
+            val column = device.findObject(By.desc("MyLazyColumn"))
+            // Set gesture margin to avoid triggering gesture navigation
+            // with input events from automation.
+            column.setGestureMargin(device.displayWidth / 5)
+
+            // Scroll down several times
+            repeat(3) { column.fling(Direction.DOWN) }
+        }
+    }
 }

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
@@ -30,6 +30,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+private const val ITERATIONS = 10
+
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class FrameTimingBenchmark {
@@ -47,7 +49,7 @@ class FrameTimingBenchmark {
             // it has on frame timing metrics.
             compilationMode = CompilationMode.None(),
             startupMode = StartupMode.WARM, // restarts activity each iteration
-            iterations = 10,
+            iterations = ITERATIONS,
             // [END_EXCLUDE]
             setupBlock = {
                 // Before starting to measure, navigate to the UI to be measured
@@ -76,7 +78,7 @@ class FrameTimingBenchmark {
             // it has on frame timing metrics.
             compilationMode = CompilationMode.None(),
             startupMode = StartupMode.WARM, // restarts activity each iteration
-            iterations = 10,
+            iterations = ITERATIONS,
             // [END_EXCLUDE]
             setupBlock = {
                 // Before starting to measure, navigate to the UI to be measured

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/SmallListStartupBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/SmallListStartupBenchmark.kt
@@ -48,6 +48,19 @@ class SmallListStartupBenchmark(
         startActivityAndWait(intent)
     }
 
+    @Test
+    fun startupCompose() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(StartupTimingMetric()),
+        iterations = 5,
+        startupMode = StartupMode.COLD,
+    ) {
+        val intent = Intent("$packageName.COMPOSE_ACTIVITY")
+        intent.putExtra("ITEM_COUNT", 5)
+
+        startActivityAndWait(intent)
+    }
+
     companion object {
         @Parameterized.Parameters(name = "mode={0}")
         @JvmStatic

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/SmallListStartupBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/SmallListStartupBenchmark.kt
@@ -27,6 +27,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
+private const val ITERATIONS = 5
+private const val LIST_ITEMS = 5
+
 @LargeTest
 @RunWith(Parameterized::class)
 class SmallListStartupBenchmark(
@@ -39,11 +42,11 @@ class SmallListStartupBenchmark(
     fun startup() = benchmarkRule.measureRepeated(
         packageName = TARGET_PACKAGE,
         metrics = listOf(StartupTimingMetric()),
-        iterations = 5,
+        iterations = ITERATIONS,
         startupMode = startupMode,
     ) {
         val intent = Intent("$packageName.RECYCLER_VIEW_ACTIVITY")
-        intent.putExtra("ITEM_COUNT", 5)
+        intent.putExtra("ITEM_COUNT", LIST_ITEMS)
 
         startActivityAndWait(intent)
     }
@@ -52,11 +55,11 @@ class SmallListStartupBenchmark(
     fun startupCompose() = benchmarkRule.measureRepeated(
         packageName = TARGET_PACKAGE,
         metrics = listOf(StartupTimingMetric()),
-        iterations = 5,
+        iterations = ITERATIONS,
         startupMode = StartupMode.COLD,
     ) {
         val intent = Intent("$packageName.COMPOSE_ACTIVITY")
-        intent.putExtra("ITEM_COUNT", 5)
+        intent.putExtra("ITEM_COUNT", LIST_ITEMS)
 
         startActivityAndWait(intent)
     }

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/SmallListStartupBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/SmallListStartupBenchmark.kt
@@ -56,7 +56,7 @@ class SmallListStartupBenchmark(
         packageName = TARGET_PACKAGE,
         metrics = listOf(StartupTimingMetric()),
         iterations = ITERATIONS,
-        startupMode = StartupMode.COLD,
+        startupMode = startupMode,
     ) {
         val intent = Intent("$packageName.COMPOSE_ACTIVITY")
         intent.putExtra("ITEM_COUNT", LIST_ITEMS)


### PR DESCRIPTION
The goal was to match the current RecyclerView sample as close as possible. This will allow us to compare the results.

### Results

Startup
```
SmallListStartupBenchmark_startup[mode=COLD]
timeToInitialDisplayMs   min 159.9,   median 168.2,   max 187.0
Traces: Iteration 0 1 2 3 4
SmallListStartupBenchmark_startupCompose[mode=COLD]
timeToInitialDisplayMs   min 163.1,   median 170.6,   max 178.1
Traces: Iteration 0 1 2 3 4
SmallListStartupBenchmark_startup[mode=WARM]
timeToInitialDisplayMs   min 78.0,   median 89.6,   max 96.7
Traces: Iteration 0 1 2 3 4
SmallListStartupBenchmark_startupCompose[mode=WARM]
timeToInitialDisplayMs   min  82.2,   median  93.9,   max 100.5
Traces: Iteration 0 1 2 3 4
```

Scroll
```
FrameTimingBenchmark_scrollList
frameCpuTimeMs   P50   2.5,   P90   3.3,   P95  10.2,   P99  16.0
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
FrameTimingBenchmark_scrollComposeList
frameCpuTimeMs   P50   2.9,   P90   5.7,   P95  10.4,   P99  12.3
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```
