### PR TITLE
Macrobenchmark GH actions filter

### DIFF
--- a/.github/workflows/firebase_test_lab.yml
+++ b/.github/workflows/firebase_test_lab.yml
@@ -6,9 +6,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  # This job checks for any file changed within MacrobenchmarkSample/ folder 
+  # to distinguish if the build check for Macrobenchmark is needed to be run.
+  # It sets the outputs.macrobenchmark to true/false based on the changes.
+  # In the next build job, it checks for needs.changes.outputs.macrobenchmark == 'true' 
+  # or skips the job otherwise.
+  changes:
+    if: github.repository_owner == 'android' 
+    runs-on: ubuntu-latest
+    # Set job outputs to values from filter step to be able to use it in next job
+    outputs:
+      macrobenchmark: ${{ steps.filter.outputs.macrobenchmark }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          macrobenchmark:
+            - 'MacrobenchmarkSample/**'
+
   build:
-    # Only run action for the main repo & not forks
-    if: github.repository_owner == 'android'
+    needs: changes
+    # Only run action for the main repo & not forks and if change is in macrobenchmark sample
+    if: github.repository_owner == 'android' && needs.changes.outputs.macrobenchmark == 'true' 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/macrobenchmark.yml
+++ b/.github/workflows/macrobenchmark.yml
@@ -8,7 +8,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  # This job checks for any file changed within MacrobenchmarkSample/ folder 
+  # to distinguish if the build check for Macrobenchmark is needed to be run.
+  # It sets the outputs.macrobenchmark to true/false based on the changes.
+  # In the next build job, it checks for needs.changes.outputs.macrobenchmark == 'true' 
+  # or skips the job otherwise.
   changes:
+    if: github.repository_owner == 'android' 
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step to be able to use it in next job
     outputs:

--- a/.github/workflows/macrobenchmark.yml
+++ b/.github/workflows/macrobenchmark.yml
@@ -8,9 +8,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Set job outputs to values from filter step to be able to use it in next job
+    outputs:
+      macrobenchmark: ${{ steps.filter.outputs.macrobenchmark }}
+    steps:
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          macrobenchmark:
+            - 'MacrobenchmarkSample/**'
+
   build:
-    # Only run action for the main repo & not forks
-    if: github.repository_owner == 'android'
+    needs: changes
+    # Only run action for the main repo & not forks and if change is in macrobenchmark sample
+    if: github.repository_owner == 'android' && needs.changes.outputs.macrobenchmark == 'true' 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/macrobenchmark.yml
+++ b/.github/workflows/macrobenchmark.yml
@@ -14,6 +14,10 @@ jobs:
     outputs:
       macrobenchmark: ${{ steps.filter.outputs.macrobenchmark }}
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
     - uses: dorny/paths-filter@v2
       id: filter
       with:


### PR DESCRIPTION
Every time we change something in the samples, it triggers the GH actions for Macrobenchmark.
This PR filters it to run only when something changes in the `MacrobenchmarkSample/` repository.

I ran the actions manually:
- full build [run](https://github.com/android/performance-samples/actions/runs/1829574883)
- skipped build [run](https://github.com/android/performance-samples/actions/runs/1829535658)