### PR TITLE
[Macrobenchmark] Remove usage of content description for Compose

### DIFF
--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
@@ -17,8 +17,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -35,13 +33,7 @@ class ComposeActivity: ComponentActivity() {
         setContent {
             MaterialTheme {
                 LazyColumn(
-                    Modifier
-                        .fillMaxSize()
-                        .semantics {
-                            // There are no view ids in Compose so we use the content description
-                            // in order to find the Composable.
-                            contentDescription = LAZY_COLUMN_TAG
-                        }
+                    Modifier.fillMaxSize()
                 ) {
                     items(data, key = { it.contents }) { item ->
                         EntryRow(entry = item, Modifier.padding(8.dp))
@@ -57,7 +49,6 @@ class ComposeActivity: ComponentActivity() {
 
     companion object {
         const val EXTRA_ITEM_COUNT = "ITEM_COUNT"
-        const val LAZY_COLUMN_TAG = "MyLazyColumn"
     }
 }
 

--- a/MacrobenchmarkSample/build.gradle
+++ b/MacrobenchmarkSample/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = "1.6.10"
-    ext.benchmark_version = "1.1.0-beta02"
+    ext.benchmark_version = "1.1.0-beta03"
     ext.compose_version = "1.1.0"
 
     repositories {

--- a/MacrobenchmarkSample/build.gradle
+++ b/MacrobenchmarkSample/build.gradle
@@ -18,14 +18,14 @@
 buildscript {
     ext.kotlin_version = "1.6.10"
     ext.benchmark_version = "1.1.0-beta02"
-    ext.compose_version = "1.1.0-rc03"
+    ext.compose_version = "1.1.0"
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0-rc01'
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
@@ -86,7 +86,12 @@ class FrameTimingBenchmark {
                 startActivityAndWait(intent)
             }
         ) {
-            val column = device.findObject(By.desc("MyLazyColumn"))
+            // Compose does not have view IDs so we have to use other methods of UIAutomator
+            // to find the correct composable. Be careful when using content description because you may
+            // break the accessibility of your app if you are providing descriptions just for tests.
+            // Here we use scrollable as the only scrollable item in the activity is our lazy list.
+            val column = device.findObject(By.scrollable(true))
+
             // Set gesture margin to avoid triggering gesture navigation
             // with input events from automation.
             column.setGestureMargin(device.displayWidth / 5)


### PR DESCRIPTION
This was encouraging a bad practice of replacing content descriptions for tests which can lead to talkback breaking. I've replaced it with `By.scrollable(true)` and a comment about other possibilities.

Also upgraded to Compose 1.1.0 stable and the latest stable gradle plugin.