### PR TITLE
Fix baseline profiles aren't supported on this device version

### DIFF
--- a/MacrobenchmarkSample/app/build.gradle
+++ b/MacrobenchmarkSample/app/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation("androidx.profileinstaller:profileinstaller:1.2.0-alpha02")
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
Compose adds older version of profileInstaller which causes Macrobenchmarks failing at startup.
The fix is to provide newer version of profile installer.

There's already bug reported to provide better error message for Macrobenchmark.

```
java.lang.RuntimeException: Baseline profiles aren't supported on this device version
	at androidx.benchmark.macro.CompilationMode$Partial.broadcastBaselineProfileInstall(CompilationMode.kt:187)
	at androidx.benchmark.macro.CompilationMode$Partial.compileImpl$benchmark_macro_release(CompilationMode.kt:210)
	at androidx.benchmark.macro.CompilationMode.resetAndCompile$benchmark_macro_release(CompilationMode.kt:68)
	at androidx.benchmark.macro.MacrobenchmarkKt.macrobenchmark(Macrobenchmark.kt:138)
	at androidx.benchmark.macro.MacrobenchmarkKt.macrobenchmarkWithStartupMode(Macrobenchmark.kt:300)
	at androidx.benchmark.macro.junit4.MacrobenchmarkRule.measureRepeated(MacrobenchmarkRule.kt:102)
	at androidx.benchmark.macro.junit4.MacrobenchmarkRule.measureRepeated$default(MacrobenchmarkRule.kt:92)
	at com.example.macrobenchmark.startup.SampleStartupBenchmark.startup(SampleStartupBenchmark.kt:36)
```
