### PR TITLE
Adds benchmark to report when app is fully drawn from Jetpack Compose.

### DIFF
--- a/MacrobenchmarkSample/app/src/main/AndroidManifest.xml
+++ b/MacrobenchmarkSample/app/src/main/AndroidManifest.xml
@@ -50,6 +50,15 @@
         </activity>
 
         <activity
+            android:name=".FullyDrawnStartupActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.macrobenchmark.target.FULLY_DRAWN_STARTUP_ACTIVITY" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".ComposeActivity"
             android:exported="true">
             <intent-filter>

--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/FullyDrawnStartupActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/FullyDrawnStartupActivity.kt
@@ -1,0 +1,44 @@
+package com.example.macrobenchmark.target
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.doOnPreDraw
+
+class FullyDrawnStartupActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TextBlock("Compose Macrobenchmark Target")
+        }
+    }
+
+    @Composable
+    fun ReportFullyDrawn(
+        text: String
+    ) {
+        val localView: View = LocalView.current
+        LaunchedEffect(text) {
+            val activity = localView.context as? Activity
+            if (activity != null) {
+                localView.doOnPreDraw {
+                    activity.reportFullyDrawn()
+                }
+            }
+        }
+    }
+
+    @Composable
+    fun TextBlock(
+        text: String,
+    ) {
+        Text(text)
+        ReportFullyDrawn(text)
+    }
+}

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/FullyDrawnStartupBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/FullyDrawnStartupBenchmark.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.macrobenchmark.startup
+
+import android.content.Intent
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.example.macrobenchmark.TARGET_PACKAGE
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class FullyDrawnStartupBenchmark {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startup() = benchmarkRule.measureRepeated(
+        packageName = TARGET_PACKAGE,
+        metrics = listOf(StartupTimingMetric()),
+        iterations = 5,
+    ) {
+        val intent = Intent()
+        intent.action = "$TARGET_PACKAGE.FULLY_DRAWN_STARTUP_ACTIVITY"
+        startActivityAndWait(intent)
+    }
+}


### PR DESCRIPTION
Bug: b/222753965
Relnote: Adds new Jetpack Compose activity and benchmark to record startup.
Test: ./gradlew :macrobenchmark:cC