### PR TITLE
Refactor versions to be compatible with any AS version

### DIFF
--- a/MacrobenchmarkSample/app/build.gradle
+++ b/MacrobenchmarkSample/app/build.gradle
@@ -20,11 +20,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdk rootProject.compileSdkVersion
     defaultConfig {
         applicationId "com.example.macrobenchmark.target"
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdk rootProject.minSdkVersion
+        targetSdk rootProject.targetSdkVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -63,33 +63,34 @@ android {
         jvmTarget = '1.8'
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = compose_version
+        kotlinCompilerExtensionVersion = composeVersion
     }
 }
 
 dependencies {
     implementation project(':shared')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
-    implementation 'androidx.activity:activity-ktx:1.4.0'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.activity:activity-compose:1.4.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation("androidx.profileinstaller:profileinstaller:1.2.0-alpha02")
+    implementation "androidx.activity:activity-ktx:$activityVersion"
+    implementation "androidx.core:core-ktx:$coreVersion"
+    implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation "com.google.android.material:material:$materialVersion"
+    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
 
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
+    implementation "androidx.activity:activity-compose:$activityVersion"
+    implementation "androidx.compose.ui:ui:$composeVersion"
+    implementation "androidx.compose.material:material:$composeVersion"
+    implementation "androidx.compose.ui:ui-tooling:$composeVersion"
 
-    implementation 'androidx.tracing:tracing-ktx:1.1.0-beta01'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation "androidx.profileinstaller:profileinstaller:$profileInstallerVersion"
+    implementation "androidx.tracing:tracing-ktx:$tracingVersion"
+
+    testImplementation "junit:junit:$jUnitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$testExtVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoCoreVersion"
 }

--- a/MacrobenchmarkSample/build.gradle
+++ b/MacrobenchmarkSample/build.gradle
@@ -16,17 +16,37 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.6.10"
-    ext.benchmark_version = "1.1.0-beta03"
-    ext.compose_version = "1.1.0"
+    ext {
+        agpVersion = "7.1.2"
+        targetSdkVersion = 31
+        minSdkVersion = 21
+        compileSdkVersion = 31
+
+        kotlinVersion = "1.6.10"
+        coroutinesVersion = "1.6.0"
+        benchmarkVersion = "1.1.0-beta06"
+        composeVersion = "1.1.1"
+        lifecycleVersion = '2.4.1'
+        tracingVersion = '1.1.0-beta01'
+        activityVersion='1.4.0'
+        coreVersion='1.7.0'
+        appcompatVersion='1.4.1'
+        materialVersion='1.5.0'
+        constraintLayoutVersion='2.1.3'
+        profileInstallerVersion = '1.2.0-alpha02'
+        jUnitVersion = '4.13.2'
+        testExtVersion = '1.1.3'
+        espressoCoreVersion = '3.4.0'
+        uiAutomatorVersion = '2.2.0'
+    }
 
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0-beta04'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.android.tools.build:gradle:$agpVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/MacrobenchmarkSample/macrobenchmark/build.gradle
+++ b/MacrobenchmarkSample/macrobenchmark/build.gradle
@@ -6,10 +6,10 @@ plugins {
 // [START macrobenchmark_setup_android]
 android {
     // [START_EXCLUDE]
-    compileSdkVersion 31
+    compileSdk rootProject.compileSdkVersion
     defaultConfig {
-        minSdkVersion 23
-        targetSdkVersion 31
+        minSdk 23 // Macrobenchmark doesn't work with SDK lower than 23
+        targetSdk rootProject.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -53,12 +53,12 @@ androidComponents {
 // [START macrobenchmark_setup_dependencies]
 dependencies {
     // [START_EXCLUDE]
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.test.ext:junit:1.1.3'
-    implementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "androidx.test.ext:junit:$testExtVersion"
+    implementation "androidx.test.espresso:espresso-core:$espressoCoreVersion"
+    implementation "androidx.test.uiautomator:uiautomator:$uiAutomatorVersion"
     // [END_EXCLUDE]
-    implementation "androidx.benchmark:benchmark-macro-junit4:$benchmark_version"
+    implementation "androidx.benchmark:benchmark-macro-junit4:$benchmarkVersion"
 }
 // [END macrobenchmark_setup_dependencies]
 

--- a/MacrobenchmarkSample/shared/build.gradle
+++ b/MacrobenchmarkSample/shared/build.gradle
@@ -20,11 +20,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdk 21
-        targetSdk 32
+        minSdk rootProject.minSdkVersion
+        targetSdk rootProject.targetSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -47,10 +47,10 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation "androidx.core:core-ktx:$coreVersion"
+    implementation "androidx.appcompat:appcompat:$appcompatVersion"
+    implementation "com.google.android.material:material:$materialVersion"
+    testImplementation "junit:junit:$jUnitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$testExtVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoCoreVersion"
 }


### PR DESCRIPTION
We need to use stable AGP, so that it's buildable with any AS version.
I know there was a problem with baseline-profiles AGP, but AFAIK it's still not resolved even in 7.3-alpha