### PR TITLE
Fix FTL github action

### DIFF
--- a/.github/workflows/firebase_test_lab.yml
+++ b/.github/workflows/firebase_test_lab.yml
@@ -56,13 +56,14 @@ jobs:
           gradle-executable: ${{ github.workspace }}/MacrobenchmarkSample/gradlew
           wrapper-directory: ${{ github.workspace }}/MacrobenchmarkSample/gradle/wrapper
 
+      - name: 'Authenticate Cloud SDK'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
+      
       - name: Run Macro Benchmarks
         run: |
           gcloud firebase test android run \

--- a/MacrobenchmarkSample/ftl/README.md
+++ b/MacrobenchmarkSample/ftl/README.md
@@ -35,7 +35,7 @@ Create a Google Cloud IAM [service account key](https://cloud.google.com/iam/doc
 Create 2 secrets:
 
 * `GCP_PROJECT_ID` represents your Google Cloud Platform `project id`. 
-* `GCP_SA_KEY` represents the service account key exported to JSON.
+* `GCP_CREDENTIALS` represents the service account key exported to JSON.
 
 Now that you have a service account, you also need to grant the service account access to the Firebase Test Lab APIs. For more information, please refer to [enabling an API for your project](https://cloud.google.com/endpoints/docs/openapi/enable-api).
 


### PR DESCRIPTION
The problem was that the token expired and the action was using deprecated way of authorization.
This is now based on https://github.com/google-github-actions/setup-gcloud#Authorization

Manually ran action [here](https://github.com/android/performance-samples/runs/6474039275?check_suite_focus=true) (currently still in progress, but successfully authorized)