### PR TITLE
Access a composable from UiAutomator

### DIFF
--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
@@ -5,25 +5,23 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Button
-import androidx.compose.material.Card
-import androidx.compose.material.Checkbox
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
-class ComposeActivity: ComponentActivity() {
+@OptIn(ExperimentalComposeUiApi::class)
+class ComposeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -35,16 +33,34 @@ class ComposeActivity: ComponentActivity() {
 
         setContent {
             MaterialTheme {
-                LazyColumn(
-                    Modifier.fillMaxSize()
+                Box(
+                    modifier = Modifier.semantics {
+                        // Allows to use testTag() for UiAutomator's resource-id.
+                        // It can be enabled high in the compose hierarchy, 
+                        // so that it's enabled for the whole subtree 
+                        testTagsAsResourceId = true
+                    }
                 ) {
-                    items(data, key = { it.contents }) { item ->
-                        EntryRow(entry = item, Modifier.padding(8.dp).clickable {
-                            ClickTrace.onClickPerformed()
-                            AlertDialog.Builder(this@ComposeActivity)
-                                .setMessage("Item clicked")
-                                .show()
-                        })
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            // Thanks to [SemanticsPropertyReceiver.testTagsAsResourceId], 
+                            // this [Modifier.testTag] will be propagated to resource-id 
+                            // and can be accessed from benchmarks.
+                            .testTag("myLazyColumn")
+                    ) {
+                        items(data, key = { it.contents }) { item ->
+                            EntryRow(entry = item,
+                                Modifier
+                                    .padding(8.dp)
+                                    .clickable {
+                                        ClickTrace.onClickPerformed()
+                                        AlertDialog
+                                            .Builder(this@ComposeActivity)
+                                            .setMessage("Item clicked")
+                                            .show()
+                                    })
+                        }
                     }
                 }
             }

--- a/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
+++ b/MacrobenchmarkSample/app/src/main/java/com/example/macrobenchmark/target/ComposeActivity.kt
@@ -5,7 +5,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.*
@@ -14,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview

--- a/MacrobenchmarkSample/build.gradle
+++ b/MacrobenchmarkSample/build.gradle
@@ -17,15 +17,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        agpVersion = '7.3.0-beta01'
-        targetSdkVersion = 31
+        agpVersion = '7.3.0-beta02'
+        targetSdkVersion = 32
         minSdkVersion = 21
-        compileSdkVersion = 31
+        compileSdkVersion = 32
 
-        kotlinVersion = "1.6.10"
+        kotlinVersion = "1.6.21"
         coroutinesVersion = "1.6.0"
-        benchmarkVersion = "1.1.0-rc02"
-        composeVersion = "1.1.1"
+        benchmarkVersion = "1.1.0-rc03"
+        composeVersion = "1.2.0-beta03"
         lifecycleVersion = '2.4.1'
         tracingVersion = '1.1.0'
         activityVersion='1.4.0'
@@ -33,7 +33,7 @@ buildscript {
         appcompatVersion='1.4.1'
         materialVersion='1.6.0'
         constraintLayoutVersion='2.1.3'
-        profileInstallerVersion = '1.2.0-beta01'
+        profileInstallerVersion = '1.2.0-beta03'
         jUnitVersion = '4.13.2'
         testExtVersion = '1.1.3'
         espressoCoreVersion = '3.4.0'

--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/frames/FrameTimingBenchmark.kt
@@ -86,11 +86,15 @@ class FrameTimingBenchmark {
                 startActivityAndWait(intent)
             }
         ) {
-            // Compose does not have view IDs so we have to use other methods of UIAutomator
-            // to find the correct composable. Be careful when using content description because you may
-            // break the accessibility of your app if you are providing descriptions just for tests.
-            // Here we use scrollable as the only scrollable item in the activity is our lazy list.
-            val column = device.findObject(By.scrollable(true))
+            /**
+             * Compose does not have view IDs so we cannot directly access composables from UiAutomator.
+             * To access a composable we need to set:
+             * 1) Modifier.semantics { testTagsAsResourceId = true } once, high in the compose hierarchy
+             * 2) Add Modifier.testTag("someIdentifier") to all of the composables you want to access
+             *
+             * Once done that, we can access the composable using By.res("someIdentifier")
+             */
+            val column = device.findObject(By.res("myLazyColumn"))
 
             // Set gesture margin to avoid triggering gesture navigation
             // with input events from automation.


### PR DESCRIPTION
Thanks to the experimental flag `testTagAsResourceId` we can now access any composable with `Modifier.testTag` from benchmarks.

+ bump versions