### PR TITLE
Increase warmup iterations to 3

### DIFF
--- a/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/StartupCompilationModeBenchmark.kt
+++ b/MacrobenchmarkSample/macrobenchmark/src/main/java/com/example/macrobenchmark/startup/StartupCompilationModeBenchmark.kt
@@ -62,7 +62,7 @@ abstract class AbstractStartupBenchmark(private val startupMode: StartupMode) {
     fun startupPartialCompilation() = startup(
         CompilationMode.Partial(
             baselineProfileMode = BaselineProfileMode.Disable,
-            warmupIterations = 1
+            warmupIterations = 3
         )
     )
 


### PR DESCRIPTION
For partial compilation, which shows baseline profile improvements, using 3 warmup iterations will provide data which is closer to data seen in the field.