### PR TITLE
Remove benchmark build type

### DIFF
--- a/MacrobenchmarkSample/app/build.gradle.kts
+++ b/MacrobenchmarkSample/app/build.gradle.kts
@@ -54,16 +54,6 @@ android {
             // In real app, this would use its own release keystore
             signingConfig = signingConfigs.getByName("debug")
         }
-
-        create("benchmark") {
-            initWith(release)
-            signingConfig = signingConfigs.getByName("debug")
-            // [START_EXCLUDE silent]
-            // Selects release buildType if the benchmark buildType not available in other modules.
-            matchingFallbacks.add("release")
-            // [END_EXCLUDE]
-            proguardFiles("benchmark-rules.pro")
-        }
     }
     // [END macrobenchmark_setup_app_build_type]
 

--- a/MacrobenchmarkSample/macrobenchmark/build.gradle.kts
+++ b/MacrobenchmarkSample/macrobenchmark/build.gradle.kts
@@ -60,18 +60,6 @@ android {
     targetProjectPath = ":app"
     // Enable the benchmark to run separately from the app process
     experimentalProperties["android.experimental.self-instrumenting"] = true
-
-    buildTypes {
-        // declare a build type to match the target app"s build type
-        create("benchmark") {
-            isDebuggable = true
-            signingConfig = signingConfigs.getByName("debug")
-            // [START_EXCLUDE silent]
-            // Selects release buildType if the benchmark buildType not available in other modules.
-            matchingFallbacks.add("release")
-            // [END_EXCLUDE]
-        }
-    }
 }
 // [END macrobenchmark_setup_android]
 


### PR DESCRIPTION
This build type is no longer needed when using the Baseline Profile Gradle plugin so we're removing it.