### PR TITLE
Add triggers to .github/workflows/

### DIFF
--- a/.github/workflows/copy-branch.yml
+++ b/.github/workflows/copy-branch.yml
@@ -5,6 +5,7 @@ name: Duplicates main to old master branch
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
 

--- a/.github/workflows/firebase_test_lab.yml
+++ b/.github/workflows/firebase_test_lab.yml
@@ -3,6 +3,8 @@ name: Runs Macro Benchmarks on Firebase Test Lab
 on:
   push:
     branches: [ macrobenchmark, main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -95,4 +97,3 @@ jobs:
             --environment-variables clearPackageData=true,additionalTestOutputDir=/sdcard/Download,no-isolated-storage=true,androidx.benchmark.enabledRules=BaselineProfile \
             --num-uniform-shards 2 \
             --timeout 30m
-

--- a/.github/workflows/generate-bp.yml
+++ b/.github/workflows/generate-bp.yml
@@ -3,6 +3,8 @@ name: Generate Baseline Profiles
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 concurrency:
@@ -77,4 +79,3 @@ jobs:
         with:
           name: "Production App"
           path: MacrobenchmarkSample/app/build/outputs/apk/release/*.apk
-      

--- a/.github/workflows/generate-bp.yml
+++ b/.github/workflows/generate-bp.yml
@@ -1,9 +1,9 @@
 name: Generate Baseline Profiles
 
 on:
+  # We ONLY want to build baseline profiles for pushes on main.
+  # Do not trigger on "pull_request" because it takes too much time and resources.
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
   workflow_dispatch:
 

--- a/.github/workflows/macrobenchmark.yml
+++ b/.github/workflows/macrobenchmark.yml
@@ -1,6 +1,7 @@
 name: Builds Macrobenchmarks
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [ macrobenchmark, main ]


### PR DESCRIPTION
This PR standardizes GitHub Actions triggers in workflow files within `.github/workflows/`.

The goal is to ensure workflows run consistently on `push`, `pull_request`, and `workflow_dispatch` events where appropriate.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.

**Project Owner:** Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

* If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
* If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.
